### PR TITLE
Update official status page when domain already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Project-specific files
 *.sqlite
+/src/StatusExposed/.config/dotnet-tools.json
 
 # User-specific files
 *.rsuser
@@ -305,8 +306,6 @@ node_modules/
 *.dsp
 
 # Visual Studio 6 technical files 
-*.ncb
-*.aps
 
 # Visual Studio LightSwitch build output
 **/*.HTMLClient/GeneratedArtifacts

--- a/src/StatusExposed/Models/StatusInformation.cs
+++ b/src/StatusExposed/Models/StatusInformation.cs
@@ -9,7 +9,7 @@ public class StatusInformation
     [Key]
     public string ServicePageDomain { get; init; } = string.Empty;
 
-    public string? StatusPageUrl { get; init; }
+    public string? StatusPageUrl { get; set; }
     public Status Status { get; set; }
     public DateTime LastUpdateTime { get; set; }
     public TimeSpan Ping { get; set; }

--- a/src/StatusExposed/Program.cs
+++ b/src/StatusExposed/Program.cs
@@ -41,7 +41,7 @@ app.UseRouting();
 app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
 
-using (IServiceScope? scope = app.Services.CreateScope())
+using (IServiceScope scope = app.Services.CreateScope())
 using (DatabaseContext? context = scope.ServiceProvider.GetService<DatabaseContext>())
 {
     ILogger? logger = scope.ServiceProvider.GetService<ILogger>();

--- a/src/StatusExposed/Services/Implementations/StatusService.cs
+++ b/src/StatusExposed/Services/Implementations/StatusService.cs
@@ -29,13 +29,17 @@ public class StatusService : IStatusService
     {
         domain = domain.Trim().ToLower();
 
-        if (mainDatabaseContext.Services.Any(s => s.ServicePageDomain == domain))
+        StatusInformation? statusInformation = await mainDatabaseContext.Services.FindAsync(domain);
+
+        if (statusInformation is not null)
         {
             logger.LogWarning("Tried to add already existing service: {domain}", domain);
+            statusInformation.StatusPageUrl = statusPageUrl;
+            _ = await mainDatabaseContext.SaveChangesAsync();
             return;
         }
 
-        StatusInformation statusInformation = new StatusInformation()
+        statusInformation = new StatusInformation()
         {
             ServicePageDomain = domain,
             StatusPageUrl = statusPageUrl,


### PR DESCRIPTION
You can now update the official status page of already existing domains by going to the `/add` page and entering the already existing domain and the new statuspage.